### PR TITLE
Accept children ReactNode instead of "value" string

### DIFF
--- a/src/DetectableOverflow.tsx
+++ b/src/DetectableOverflow.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { default as ReactResizeDetector } from 'react-resize-detector';
 
 export interface Props {
-  value: string;
   tag?: string;
   style?: object;
   className?: string;
@@ -70,7 +69,7 @@ export class DetectableOverflow extends React.Component<Props, States> {
       tag,
       props,
       <ReactResizeDetector handleWidth onResize={this.updateState} />,
-      this.props.value,
+      this.props.children,
     );
   }
 }

--- a/test/DetectableOverflow.test.tsx
+++ b/test/DetectableOverflow.test.tsx
@@ -4,19 +4,19 @@ import DetectableOverflow from '../src';
 
 describe('DetectableOverflow', () => {
   it('renders a `div` element.', () => {
-    const wrapper = enzyme.shallow(<DetectableOverflow value="a"/>);
+    const wrapper = enzyme.shallow(<DetectableOverflow>a</DetectableOverflow>);
     expect(wrapper.find('p').exists()).toBeFalsy();
     expect(wrapper.find('div').exists()).toBeTruthy();
   });
 
   it('renders an element whose type is `tag` argument.', () => {
-    const wrapper = enzyme.shallow(<DetectableOverflow value="a" tag="abc"/>);
+    const wrapper = enzyme.shallow(<DetectableOverflow tag="abc">a</DetectableOverflow>);
     expect(wrapper.find('div').exists()).toBeFalsy();
     expect(wrapper.find('abc').exists()).toBeTruthy();
   });
 
   it('renders `value` argument as a child', () => {
-    const wrapper = enzyme.shallow(<DetectableOverflow value="abc"/>);
+  const wrapper = enzyme.shallow(<DetectableOverflow>abc</DetectableOverflow>);
     expect(wrapper.find('div').childAt(1).text()).toEqual('abc');
   });
 });


### PR DESCRIPTION
Loosen this component to accept/use children instead of a parametrized "value" string.