### PR TITLE
Replace setupTestFrameworkScriptFile with setupFilesAfterEnv

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
       "js",
       "json"
     ],
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setup.ts"
+    "setupFilesAfterEnv": [
+      "<rootDir>/test/setup.ts"
+    ]
   }
 }


### PR DESCRIPTION
Remove deprecation warning

> react-detectable-overflow/ yarn test
> yarn run v1.21.1
> $ yarn lint && yarn jest
> $ tslint 'src/**/*.ts{,x}'
> $ jest
> 
> Deprecation Warning:
>
>  Option "setupTestFrameworkScriptFile" was replaced by configuration "setupFilesAfterEnv", which supports multiple paths.
> 
>  Please update your configuration.
>
>  Configuration Documentation:
>  https://jestjs.io/docs/configuration.html