### PR TITLE
React 17 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "react-resize-detector": "^5.2.0"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": ">=16.0.0",
+    "react-dom": ">=16.0.0"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Peer deps only allow react 16

```
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.0.0" from react-detectable-overflow@0.5.0
npm ERR! node_modules/react-detectable-overflow
npm ERR!   react-detectable-overflow@"git@github.com:h-kanazawa/react-detectable-overflow.git#master" from jetbridge-ats@0.5.0
```