### PR TITLE
Upgrade react-resize-detector

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   "bugs": {
     "url": "https://github.com/h-kanazawa/react-detectable-overflow/issues"
   },
-  "engines": {
-    "node": ">=18"
-  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "react-resize-detector": "^8.0.3"
+    "react-resize-detector": "^8.0.4"
   },
   "peerDependencies": {
     "react": "^16.0.0 || ^17.0.0 || ^18.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "outDir": "./dist",
     "strict": true,
     "jsx": "react",
-    "sourceMap": true
+    "sourceMap": true,
+    "esModuleInterop": true
   },
   "include": [
     "./src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2942,10 +2942,10 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-resize-detector@^8.0.3:
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-8.0.3.tgz#dab4470aae23bb07deb857230ccf945d000ef99b"
-  integrity sha512-c3eqm5BVcluVhxHsBQnhyPO/5uYB3XHIHz6D1ZOHzU2WcnZF0Cr3KLl5OIozRC2RSsdQlu5vn1PHEqrvKRnIYA==
+react-resize-detector@^8.0.4:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-resize-detector/-/react-resize-detector-8.1.0.tgz#1c7817db8bc886e2dbd3fbe3b26ea8e56be0524a"
+  integrity sha512-S7szxlaIuiy5UqLhLL1KY3aoyGHbZzsTpYal9eYMwCyKqoqoVLCmIgAgNyIM1FhnP2KyBygASJxdhejrzjMb+w==
   dependencies:
     lodash "^4.17.21"
 


### PR DESCRIPTION
- Upgrade react-resize-detector to get the fix of type of `targetRef`
  - https://github.com/maslianok/react-resize-detector/pull/234
- Remove engines from package.json